### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,41 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|string||
+### Association
+- has_many :groups, through: :groups_users
+- has_many :groups_users
+- has_many :comments
+
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|string||
+### Association
+- has_many :users, through: :groups_users
+- has_many :groups_users
+- has_many :comments
+
+## commentsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|text|text||
+|img|text||
+|user|reference|null: false, foreign_key: true|
+|group|reference|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group
+
+## groups_usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user|reference|null: false, foreign_key: true|
+|group|reference|null: false, foreign_key: true|
+### Association
+- belongs_to :group
+- belongs_to :user


### PR DESCRIPTION
# What
groupsテーブルとusersテーブルの中間テーブルを作成。テーブル
名、カラム名、カラムの型、カラムのオプション、アソシエーションをマークダウンでREADME.mdに記述した。

# Why
groupsテーブルとusersテーブルが多対多の関係になっていた為。